### PR TITLE
Fixed Command Injection- docker-compose-remote-api

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var fs = require("fs"),
     yaml = require("js-yaml"),
     Docker = require('dockerode'),
-    exec = require('child_process').exec,
+    exec = require('child_process').execFile,
     spawn = require("child_process").spawn;
 
 module.exports = function(options) {
@@ -21,7 +21,7 @@ module.exports = function(options) {
          * @return void 
          */
         build: function(fnStdout, fnStderr, fnExit){
-            var execDockerCompose  = exec("docker-compose build", { cwd: cwd });
+            var execDockerCompose  = exec("docker-compose", ["compose"], { cwd: cwd });
             execDockerCompose.stdout.on('data', function(data) { if(typeof fnStdout == "function") fnStdout(data.toString()); });
             execDockerCompose.stderr.on('data', function(data) { if(typeof fnStderr == "function") fnStderr(data.toString()); });
             execDockerCompose.on("exit", fnExit);
@@ -36,7 +36,7 @@ module.exports = function(options) {
          * @return void
          */
         create: function(fnStdout, fnStderr, fnExit){
-            var execDockerCompose  = exec("docker-compose create --force-recreate --build", { cwd: cwd });
+            var execDockerCompose  = exec("docker-compose", [ "create", "--force-recreate" ,"--build"], { cwd: cwd });
             execDockerCompose.stdout.on('data', function(data) { if(typeof fnStdout == "function") fnStdout(data.toString()); });
             execDockerCompose.stderr.on('data', function(data) { if(typeof fnStderr == "function") fnStderr(data.toString()); });
             execDockerCompose.on("exit", fnExit);
@@ -59,7 +59,7 @@ module.exports = function(options) {
          * @return void
          */
         down: function(fnStdout, fnStderr, fnExit){
-            var execDockerCompose  = exec("docker-compose down --remove-orphans", { cwd: cwd });
+            var execDockerCompose  = exec("docker-compose",[ "down" ,"--remove-orphans"], { cwd: cwd });
             execDockerCompose.stdout.on('data', function(data) { if(typeof fnStdout == "function") fnStdout(data.toString()); });
             execDockerCompose.stderr.on('data', function(data) { if(typeof fnStderr == "function") fnStderr(data.toString()); });
             execDockerCompose.on("exit", fnExit);
@@ -88,7 +88,7 @@ module.exports = function(options) {
          * @return void
          */
         exec: function(serviceName, cmd, fnStdout, fnStderr, fnExit){
-            var execDockerCompose  = exec("docker-compose exec " + serviceName + " " + cmd, { cwd: cwd });
+            var execDockerCompose  = exec("docker-compose",  ["exec", serviceName, cmd], { cwd: cwd });
             execDockerCompose.stdout.on('data', function(data) { if(typeof fnStdout == "function") fnStdout(data.toString()); });
             execDockerCompose.stderr.on('data', function(data) { if(typeof fnStderr == "function") fnStderr(data.toString()); });
             execDockerCompose.on("exit", fnExit);
@@ -104,7 +104,7 @@ module.exports = function(options) {
          * @return void
          */
         kill: function(serviceName, fnStdout, fnStderr, fnExit){
-            var execDockerCompose  = exec("docker-compose kill -s SIGINT " + serviceName, { cwd: cwd });
+            var execDockerCompose  = exec("docker-compose", ["kill", "-s", "SIGINT", serviceName], { cwd: cwd });
             execDockerCompose.stdout.on('data', function(data) { if(typeof fnStdout == "function") fnStdout(data.toString()); });
             execDockerCompose.stderr.on('data', function(data) { if(typeof fnStderr == "function") fnStderr(data.toString()); });
             execDockerCompose.on("exit", fnExit);
@@ -120,7 +120,7 @@ module.exports = function(options) {
          * @return void
          */
         restart: function(serviceName, fnStdout, fnStderr, fnExit){
-            var execDockerCompose  = exec("docker-compose restart " + serviceName, { cwd: cwd });
+            var execDockerCompose  = exec("docker-compose", ["restart", serviceName], { cwd: cwd });
             execDockerCompose.stdout.on('data', function(data) { if(typeof fnStdout == "function") fnStdout(data.toString()); });
             execDockerCompose.stderr.on('data', function(data) { if(typeof fnStderr == "function") fnStderr(data.toString()); });
             execDockerCompose.on("exit", fnExit);
@@ -136,7 +136,7 @@ module.exports = function(options) {
          * @return void
          */
         rm: function(serviceName, fnStdout, fnStderr, fnExit){
-            var execDockerCompose  = exec("docker-compose rm -f " + serviceName, { cwd: cwd });
+            var execDockerCompose  = exec("docker-compose", ["rm","-f", "serviceName"], { cwd: cwd });
             execDockerCompose.stdout.on('data', function(data) { if(typeof fnStdout == "function") fnStdout(data.toString()); });
             execDockerCompose.stderr.on('data', function(data) { if(typeof fnStderr == "function") fnStderr(data.toString()); });
             execDockerCompose.on("exit", fnExit);
@@ -153,7 +153,7 @@ module.exports = function(options) {
          * @return void
          */
         run: function(serviceName, cmd, fnStdout, fnStderr, fnExit){
-            var execDockerCompose  = exec("docker-compose run " + serviceName + " " + cmd, { cwd: cwd });
+            var execDockerCompose  = exec("docker-compose", ["run", serviceName, cmd], { cwd: cwd });
             execDockerCompose.stdout.on('data', function(data) { if(typeof fnStdout == "function") fnStdout(data.toString()); });
             execDockerCompose.stderr.on('data', function(data) { if(typeof fnStderr == "function") fnStderr(data.toString()); });
             execDockerCompose.on("exit", fnExit);
@@ -166,7 +166,7 @@ module.exports = function(options) {
          */
         ps: function(cb){
             var ps = "";
-            var execDockerCompose = exec("docker-compose ps", { cwd: cwd });
+            var execDockerCompose = exec("docker-compose", ["ps"], { cwd: cwd });
             execDockerCompose.stdout.on('data', function(data) { ps += data.toString() });
             execDockerCompose.on('exit', function(data) { 
                 var lines = ps.split("\n");
@@ -198,7 +198,7 @@ module.exports = function(options) {
          * @return void
          */
         up: function(fnStdout, fnStderr, fnExit){
-            var execDockerCompose = exec("docker-compose up -d --remove-orphans", { cwd: cwd });
+            var execDockerCompose = exec("docker-compose", [ "up", "-d", "--remove-orphans"], { cwd: cwd });
             execDockerCompose.stdout.on('data', function(data) { if(typeof fnStdout == "function") fnStdout(data.toString()); });
             execDockerCompose.stderr.on('data', function(data) { if(typeof fnStderr == "function") fnStderr(data.toString()); });
             execDockerCompose.on("exit", fnExit);
@@ -242,7 +242,7 @@ module.exports = function(options) {
              * @return void
              */
             getContainerId: function(containerName, fn){
-                exec("docker-compose ps -q " + containerName, { cwd: options.cwd }, function(err, stdout, stderr){
+                exec("docker-compose", [ "ps" ,"-q" ,containerName], { cwd: options.cwd }, function(err, stdout, stderr){
                     if(err) fn(err, null);
                     else if(stderr) fn(stderr, null);
                     else if(stdout) fn(null, stdout.replace("\r", "").replace("\n", "").substr(0, 12));


### PR DESCRIPTION
### 📊 Metadata *

Command injection vulnerability 
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-docker-compose-remote-api

### ⚙️ Description *

docker-compose-remote-api is a Connection interface between docker-compose and the Docker Remote API, this package is vulnerable to Command Injection. 
Within the index.js file of the package, the function `exec(serviceName, cmd, fnStdout, fnStderr, fnExit)` uses the variable `serviceName` which can be controlled by users without any sanitization.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Install the package and run the below code:
```javascript
var Root = require("docker-compose-remote-api");
var root = Root({cwd:__dirname}).exec("& touch vulnerable.txt");
```

### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

![image](https://user-images.githubusercontent.com/16708391/92393984-5ab06f00-f13e-11ea-9330-dd061d50ac89.png)



### 👍 User Acceptance Testing (UAT)

Only `execFile` is used, no breaking changes introduced.
